### PR TITLE
Use transients to store persistently. 

### DIFF
--- a/php/Meter.php
+++ b/php/Meter.php
@@ -10,13 +10,15 @@
 
 namespace Cedaro\WPRESTCop;
 
+use jsonSerializable;
+
 /**
  * Meter class.
  *
  * @package Cedaro\WPRESTCop
  * @since   1.0.0
  */
-class Meter implements \jsonSerializable {
+class Meter implements jsonSerializable {
 	/**
 	 * Unique meter identifier.
 	 *
@@ -126,7 +128,7 @@ class Meter implements \jsonSerializable {
 	 * @return bool
 	 */
 	public function is_limit_exceeded() {
-		return 0 > $this->get_remaining();
+		return apply_filters( 'wp_rest_cop_is_limit_exceeded', ( 0 > $this->get_remaining() ), $this->get_id(), $this );
 	}
 
 	/**
@@ -137,7 +139,7 @@ class Meter implements \jsonSerializable {
 	 * @return int
 	 */
 	public function get_remaining() {
-		return $this->remaining;
+		return apply_filters( 'wp_rest_cop_remaining', $this->remaining, $this->get_id(), $this );
 	}
 
 	/**

--- a/php/MeterMaid.php
+++ b/php/MeterMaid.php
@@ -28,7 +28,7 @@ class MeterMaid {
 	 * @return Meter
 	 */
 	public static function make( $id, $limit, $interval ) {
-		$meter = get_transient( self::get_cache_key( $id ) );
+		$meter = wp_cache_get( self::get_cache_key( $id ), 'wprestcop' );
 		if ( false === $meter ) {
 			$meter = new Meter( $id, $limit, $interval );
 		}
@@ -44,9 +44,10 @@ class MeterMaid {
 	 * @param Meter $meter Meter instance.
 	 */
 	public static function save( Meter $meter ) {
-		set_transient(
+		wp_cache_set(
 			self::get_cache_key( $meter->get_id() ),
 			$meter,
+			'wprestcop',
 			$meter->get_reset()
 		);
 	}

--- a/php/MeterMaid.php
+++ b/php/MeterMaid.php
@@ -28,7 +28,7 @@ class MeterMaid {
 	 * @return Meter
 	 */
 	public static function make( $id, $limit, $interval ) {
-		$meter = wp_cache_get( self::get_cache_key( $id ), 'wprestcop' );
+		$meter = get_transient( self::get_cache_key( $id ) );
 		if ( false === $meter ) {
 			$meter = new Meter( $id, $limit, $interval );
 		}
@@ -44,10 +44,9 @@ class MeterMaid {
 	 * @param Meter $meter Meter instance.
 	 */
 	public static function save( Meter $meter ) {
-		wp_cache_set(
+		set_transient(
 			self::get_cache_key( $meter->get_id() ),
 			$meter,
-			'wprestcop',
 			$meter->get_reset()
 		);
 	}

--- a/php/Plugin.php
+++ b/php/Plugin.php
@@ -228,6 +228,13 @@ class Plugin extends AbstractPlugin {
 			return $response;
 		}
 
+		/**
+		 * Allow skipping throttle for certain requests
+		 */
+		if ( apply_filters( 'wprestcop_skip_throttle', false, $request, $server ) ) {
+			return $response;
+		}
+
 		$meter = MeterMaid::make(
 			$this->get_client_id(),
 			$this->get_rate_limit(),


### PR DESCRIPTION
Added filters to allow excluding admin from rate limits (e.g. Gutenberg).

See https://github.com/dennisnissle/wprestcop/pull/1 & https://github.com/dennisnissle/wprestcop/pull/2