### PR TITLE
Remove roave/security-advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,6 @@
     "phpcompatibility/php-compatibility": "*",
     "phpstan/extension-installer": "^1.4",
     "rector/rector": "^2.0",
-    "roave/security-advisories": "dev-latest",
     "roots/wordpress-no-content": "^6.8",
     "slevomat/coding-standard": "~8.18",
     "squizlabs/php_codesniffer": "^3.2",


### PR DESCRIPTION
Because of https://github.com/Roave/SecurityAdvisories/pull/132